### PR TITLE
Add support for average pace

### DIFF
--- a/lib/fatigue/garmin.rb
+++ b/lib/fatigue/garmin.rb
@@ -175,7 +175,7 @@ module Fatigue
 
     # Verifies whether the ajax response returned is succesful or not.
     #
-    # Returns a Boolean value for whether the ajax response was succesful or not.
+    # Returns a Boolean value for whether the ajax response was successful or not.
     def verify_ajax_response(html_body)
       html = Nokogiri::HTML(html_body)
       !html.xpath("//meta[@id='Ajax-Response' and @content='true']").empty?

--- a/lib/fatigue/garmin.rb
+++ b/lib/fatigue/garmin.rb
@@ -182,6 +182,6 @@ module Fatigue
     end
 
 
-   end
+  end
 
 end

--- a/lib/fatigue/run.rb
+++ b/lib/fatigue/run.rb
@@ -75,6 +75,19 @@ module Fatigue
     end
 
 
+    # Public: The pace of the run.
+    #
+    # speed: The String pace of the run in minutes per mile (mmm:ss).
+    def pace 
+      pace_f = (duration.to_f / 1000 / 60) / distance_to_mi
+      mins = pace_f.to_i
+      secs = (pace_f - mins) * 60
+      p = "%d:%02d" % [mins, secs]
+      puts p
+      p
+    end
+
+
     # Public: The time the run was started.
     #
     # started_at: The String time in ISO 8601.
@@ -102,6 +115,17 @@ module Fatigue
 
     # Public: The description of the run.
     attr_reader :description
+
+
+  # INTERNAL METHODS #########################################################
+
+    # Private: The distance of the run in miles.
+    def distance_to_mi
+      case @unit
+      when 'mi' then distance.to_f
+      when 'km' then distance.to_f * 0.621371192
+      end
+    end
 
   end
 

--- a/test/test_run.rb
+++ b/test/test_run.rb
@@ -8,7 +8,13 @@ context "Run" do
   
   test "basic setters" do
     @run.duration = 5
-    assert_equal 5,   @run.duration
+    assert_equal 5, @run.duration
+
+    @run.distance = 7
+    assert_equal 7, @run.distance
+
+    @run.unit = 'km'
+    assert_equal 'Kilometers', @run.unit
 
     @run.calories = 100
     assert_equal 100, @run.calories
@@ -38,6 +44,19 @@ context "Run" do
   test "hours" do
     @run.duration = 5000000
     assert_equal 1, @run.hours
+  end
+
+  test "distance conversion" do
+    @run.distance = '1'
+    @run.unit = 'km'
+    assert_in_delta 0.621, @run.distance_to_mi, 0.001
+  end
+
+  test "pace" do
+    @run.distance = 14.484096 
+    @run.unit = 'km'
+    @run.duration = 5400000 
+    assert_equal '10:00', @run.pace
   end
 
 end


### PR DESCRIPTION
- The average pace can't be posted like other fields, but can be calculated indirectly, server-side, if you make the right ajax posts. Here they are.
- Before I figured that out, I changed run so it could calculate its own average pace. Should Garmin ever shake things up, this might be useful. I left the changes.
